### PR TITLE
Quick fixes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,20 +1,19 @@
 @font-face {
-  font-family: "Camphor";
-  src: url("https://storage.googleapis.com/stripe-fonts/400-regular.woff2")
-    format("woff2");
+  font-family: 'Camphor';
+  src: url('https://storage.googleapis.com/stripe-fonts/400-regular.woff2')
+    format('woff2');
 }
 
 @font-face {
-  font-family: "Camphor Medium";
-  src: url("https://storage.googleapis.com/stripe-fonts/500-medium.woff2")
-    format("woff2");
+  font-family: 'Camphor Medium';
+  src: url('https://storage.googleapis.com/stripe-fonts/500-medium.woff2')
+    format('woff2');
 }
 
-
 @font-face {
-  font-family: "StripeIcons";
-  src: url("https://storage.googleapis.com/stripe-fonts/stripe-icons.woff2")
-    format("woff2");
+  font-family: 'StripeIcons';
+  src: url('https://storage.googleapis.com/stripe-fonts/stripe-icons.woff2')
+    format('woff2');
 }
 
 * {
@@ -82,21 +81,21 @@ body {
   display: flex;
   -ms-flex-direction: column;
   flex-direction: column;
-  font-family: "Camphor", Segoe UI, sans-serif;
+  font-family: 'Camphor', Segoe UI, sans-serif;
   font-weight: 400;
   font-style: normal;
   -webkit-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  font-feature-settings: "pnum";
+  font-feature-settings: 'pnum';
   font-variant-numeric: proportional-nums;
   position: relative;
 }
 
 body,
 html {
-  font-family: "Camphor", sans-serif;
+  font-family: 'Camphor', sans-serif;
   color: #32325d;
   min-height: 100%;
 }
@@ -114,12 +113,12 @@ html {
 .stripe:nth-child(1) {
   background-color: #e6ebf1;
   grid-row: 5;
-  grid-column: 1 / 3;  
+  grid-column: 1 / 3;
 }
 
 .stripe:nth-child(2) {
   grid-row: 6;
-  grid-column: 1/8;  
+  grid-column: 1/8;
   background-color: #43458b;
 }
 
@@ -172,7 +171,7 @@ nav a {
 
 nav a.arrow::after {
   font: normal 16px StripeIcons;
-  content: "\279E";
+  content: '\279E';
   padding-left: 6px;
 }
 
@@ -207,7 +206,7 @@ p {
   font-size: 1.7rem;
   line-height: 2.4rem;
   font-weight: 400;
-  font-family: "Camphor", Segoe UI, sans-serif;
+  font-family: 'Camphor', Segoe UI, sans-serif;
 }
 
 .demos {
@@ -334,7 +333,7 @@ h2#subscribe {
 }
 
 .title {
-  margin: 15px 0px;  
+  margin: 15px 0px;
   font-size: 1.7rem;
   line-height: 2.6rem;
   font-weight: 600;
@@ -393,11 +392,6 @@ a.button:hover {
   -webkit-box-shadow: 0 7px 14px rgba(50, 50, 93, 0.1),
     0 3px 6px rgba(0, 0, 0, 0.08);
   background: #7795f8;
-}
-
-.archive,
-.sign-up {
-  padding: 0px 40px 40px 40px;
 }
 
 .sign-up {

--- a/index.html
+++ b/index.html
@@ -96,6 +96,10 @@
             </section>
             <h2>Developer tools</h2>
             <section class="tools">
+                <a href="https://stripe.com/docs/stripe-cli" target="_blank">
+                    <h3 class="uppercase">Stripe CLI</h3>
+                    <p>Build, test, and manage your integration with Stripe directly from your terminal.</p>
+                </a>
                 <a href="https://github.com/stripe/openapi" target="_blank">
                     <h3 class="uppercase">OpenAPI Spec</h3>
                     <p>Check out our OpenAPI spec for the latest updates to the Stripe API.</p>
@@ -109,13 +113,9 @@
                     <h3 class="uppercase">Stripe Elements</h3>
                     <p>Create the checkout page of your dreams with example forms built with Elements.</p>
                 </a>
-                <a href="https://stripe.dev/react-stripe-elements" target="_blank">
-                    <h3 class="uppercase">React Elements</h3>
+                <a href="https://github.com/stripe/react-stripe-js#react-stripejs" target="_blank">
+                    <h3 class="uppercase">React Stripe.js</h3>
                     <p>Building a React app? Use our React components to quickly build a checkout form.</p>
-                </a>
-                <a href="https://github.com/stripe/stripe-webhook-monitor" target="_blank">
-                    <h3 class="uppercase">Webhook Monitor</h3>
-                    <p>Our Webhook Monitor is a live feed and graph of your recent webhook events.</p>
                 </a>
             </section>
             <h2>Client libraries</h2>
@@ -179,17 +179,9 @@
                         </div>
                     </form>
                 </div>
-                <div class="archive">
-                    <ul>
-                        <li>Archives:</li>
-                        <li><a href="https://stripemail.createsend.com/campaigns/reports/viewCampaign.aspx?d=d&c=7CA158CD0A57402E&ID=94EC6240E9E286EC2540EF23F30FEDED&temp=False&tx=0" target="_blank">May 2019</a></li>
-                        <li><a href="https://stripemail.createsend.com/campaigns/reports/viewCampaign.aspx?d=d&c=7CA158CD0A57402E&ID=E5495BB01A8E19B72540EF23F30FEDED&temp=False&tx=0" target="_blank">March 2019</a></li>
-                        <li><a href="https://stripemail.createsend.com/campaigns/reports/viewCampaign.aspx?d=d&c=7CA158CD0A57402E&ID=17A9814FC873EAAC2540EF23F30FEDED&temp=False&tx=0" target="_blank">February 2019</a></li>
-                        <li><a href="https://stripemail.createsend.com/campaigns/reports/viewCampaign.aspx?d=d&c=7CA158CD0A57402E&ID=A8E0AF2FC66664BB2540EF23F30FEDED&temp=False&tx=0" target="_blank">November 2018</a></li>
-                        <li><a href="https://stripemail.createsend.com/campaigns/reports/viewCampaign.aspx?d=d&c=7CA158CD0A57402E&ID=A3C45E8E583601BC2540EF23F30FEDED&temp=False&tx=0" target="_blank">August 2018</a></li>
-                        <li><a href="https://stripemail.createsend.com/campaigns/reports/viewCampaign.aspx?d=d&c=7CA158CD0A57402E&ID=ADA3E1BAB85DEDCA2540EF23F30FEDED&temp=False&tx=0" target="_blank">June 2018</a></li>
-                    </ul>
-                </div>
+                <p>
+                    Read previous issues on <a href="https://dev.to/t/stripedevdigest" target="_blank">DEV.to</a>
+                </p>
             </section>
         </main>
     </div>

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
                     </form>
                 </div>
                 <p>
-                    Read previous issues on <a href="https://dev.to/t/stripedevdigest" target="_blank">DEV.to</a>
+                    Read recent digests on <a href="https://dev.to/t/stripedevdigest" target="_blank">DEV.to</a>
                 </p>
             </section>
         </main>


### PR DESCRIPTION
r? @trag-stripe 

- Feature Stripe CLI in Developer tools instead of Webhook Monitor
- Update  deprecated React Elements to point to new React Stripe.js library instead.

![image](https://user-images.githubusercontent.com/23213994/85193352-596b6500-b2fa-11ea-85bb-cdeb7214bbfd.png)

- Remove archives list
- Link to DEV.to digest feed instead

![image](https://user-images.githubusercontent.com/23213994/85193370-7d2eab00-b2fa-11ea-80c3-51003d33bd7a.png)
