### PR TITLE
Set X-Requested-With header with developer digest form XMLHttpRequest

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,6 +394,7 @@
                     errorContainer.classList
                         .add('visible');
                 }
+                request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                 request.send(new FormData(form));
             });
         })();


### PR DESCRIPTION
Set the `X-Requested-With` header when making the developer digest signup request so it can be validated by `stripe.com`'s web security protections.