### PR TITLE
Stripe.dev: Dev Digest form -> Link

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -279,6 +279,12 @@ h2#subscribe {
   text-align: center;
 }
 
+.newsletter .sign-up {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: left;
+}
+
 .tools a {
   -webkit-box-flex: 1;
   -ms-flex: 1 1 100%;

--- a/index.html
+++ b/index.html
@@ -329,23 +329,11 @@
             <h2 id="subscribe">Developer digest</h2>
             <section class="newsletter">
                 <div class="sign-up">
-                    <p>Stay up to date with the latest from Stripe’s API and developer products:</p>
-                    <form id="subForm" class="js-cm-form" action="https://stripe.com/developer-digest/subscribe"
-                        method="post">
-                        <div class="collect-email">
-                            <input id="fieldEmail" placeholder="Email" name="email" type="email"
-                                class="js-cm-email-input" required />
-                            <button class="js-cm-submit-button" type="submit">Get updates</button>
-                        </div>
-                        <div class="js-email-error collect-email-error">
-                            You might have had an internet hiccup. Try again?
-                        </div>
-                    </form>
+                    <p>
+                        Stay up to date with the latest from Stripe’s API and developer products:
+                        <a href="https://go.stripe.global/dev-digest" target="_blank" rel="noopener noreferrer">Subscribe to the Stripe Developer Digest</a>, and read recent issues on <a href="https://dev.to/t/stripedevdigest" target="_blank">dev.to</a>
+                    </p>
                 </div>
-                <p>
-                    Read recent issues on <a href="https://dev.to/t/stripedevdigest" target="_blank">dev.to</a>
-                </p>
-
                 <p><br><br><a href="http://twitter.com/stripedev"><img src="images/twitter.svg" alt="Twitter" class="social-icon"></a>   <a href="https://stackoverflow.com/questions/tagged/stripe-payments">&nbsp;&nbsp;&nbsp;&nbsp;<img src="images/stackoverflow.svg" alt="Stackoverflow" class="social-icon"></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://dev.to/stripe"><img src="images/devto.svg" alt="dev.to" class="social-icon"></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://youtube.com/stripedevelopers"><img src="images/youtube.svg" alt="YouTube" class="social-icon"></a></p>
 
             </section>


### PR DESCRIPTION
This PR removes a broken sign-up form for the Dev Digest,  and replaces it with a link to go.stripe.global/dev-digest