### PR TITLE
Revert "chore: remove CNAME file to detach the stripe.dev domain from gh pages" for rollback

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+stripe.dev


### PR DESCRIPTION
Reverts stripe/stripe.github.io#34