### PR TITLE
Update redirect and rewrite rules for Terminal Java SDK sub-site

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -106,6 +106,11 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: "/stripe-terminal-java",
+        destination: "/stripe-terminal-java/index.html",
+        permanent: true,
+      },
+      {
         source: "/stripe.github.io",
         destination: "/",
         permanent: true,
@@ -134,6 +139,10 @@ const nextConfig = {
       {
         source: "/stripe-terminal-android/(.*)",
         destination: "https://stripe-terminal-android-nine.vercel.app/$1"
+      },
+      {
+        source: "/stripe-terminal-java/(.*)",
+        destination: "https://stripe-terminal-java-ten.vercel.app/$1"
       },
       {
         source: "/stripe-react-native/(.*)",


### PR DESCRIPTION
Expected URL: https://stripe.dev/stripe-terminal-java
Hosting URL: https://stripe-terminal-java-ten.vercel.app/
Repository URL: https://github.com/stripe/stripe-terminal-java
Building steps of your document: Builds are generated from the latest master branch, all content is located in the `docs` folder. If you need a similar reference, you can use https://github.com/stripe/stripe-terminal-android as the basis.